### PR TITLE
Added build for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can manually download the latest release [here](https://github.com/egoist/de
 
 ## Todo
 
-- Package for Windows/Linux
+- Package for Linux
 
 ## Development
 

--- a/build/build.js
+++ b/build/build.js
@@ -55,7 +55,7 @@ platforms.linux = () => {
 platforms.windows = () => {
   packager(Object.assign({}, defaults, {
     platform: 'win32',
-    arch: 'ia32',
+    arch: 'ia32,x64',
     icon: './build/icon.ico',
     'version-string': {
       productName: pkg.productName
@@ -63,6 +63,7 @@ platforms.windows = () => {
   }), (err, paths) => {
     cb(err, paths)
     exec(`cd dist/devdocs-win32-ia32 && zip -ryXq9 ../devdocs-windows-${pkg.version}.zip *`)
+    exec(`cd dist/devdocs-win32-x64 && zip -ryXq9 ../devdocs-windows-${pkg.version}_x64.zip *`)
   })
 }
 


### PR DESCRIPTION
Build for Windows(32/64) [here](https://github.com/alexandr-san4ez/devdocs-app/releases/download/v0.0.3/devdocs-windows-0.0.3_ia32_x64.7z).