### PR TITLE
Fixed readme build-in typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 When closing the window, the app will continue running in the background, in the dock on macOS and the tray on Linux/Windows. Right-click the dock/tray icon and choose Quit to completely quit the app. On macOS, click the dock icon to show the window. On Linux, right-click the tray icon and choose Toggle to toggle the window. On Windows, click the tray icon to toggle the window.
 
-### Build-in shortcuts
+### Built-in shortcuts
 
 `devdocs` the website itself has great built-in shortcuts support, just check the `help` page in the app.
 


### PR DESCRIPTION
I think the correct word should be `Built-int` and not `Build-in`