### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use <kbd>Ctrl+Shift+D</kbd> (or <kbd>Command+Shift+D</kbd> on macOS) to toggle t
 ### Using Homebrew
 
 ```
-brew cask install devdocs
+brew install --cask devdocs
 ```
 
 ### Manual download


### PR DESCRIPTION
Use `brew install --cask` instead of `brew cask install`

Close #152 