### PR TITLE
Fix header causing overflow (Windows, Linux?)

### DIFF
--- a/app/renderer/style.css
+++ b/app/renderer/style.css
@@ -59,7 +59,7 @@ body {
 
 .header {
   height: 24px;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   font-size: 12px;


### PR DESCRIPTION
Closes https://github.com/egoist/devdocs-desktop/issues/120.

On darwin, the following takes precedence (after, more specific) : 
```css
.is-darwin .header {
  display: flex;
}
```